### PR TITLE
Slug prefix feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Directus Operation Extension: Unique Slugify
 
-This Directus operation extension ensures that the `slug` (another field can be selected) field of a collection is unique by generating a slug based on the `title` (another field can be selected) field. If the generated slug already exists, it appends a numeric suffix to make it unique.
+This Directus operation extension ensures that the `slug` (another field can be selected) field of a collection is unique by generating a slug based on the `title` (another field can be selected) field and add anm optional slug prefix. If the generated slug already exists, it appends a numeric suffix to make it unique.
 
 ## Features
 
-- Generates a slug from the title field.
+- Generates a slug from the title field with an optional prefix.
 - Ensures the slug is unique by appending a numeric suffix.
 - Uses `date_updated` and `date_created` to determine the most recent slug for uniqueness.
 
@@ -36,6 +36,7 @@ This Directus operation extension ensures that the `slug` (another field can be 
    - Configure the options:
      - Field to be used for slugging
      - Field that slug should be assigned
+     - Field that defines optional slug prefix
      - Define a character to be used space replacement
 
 4. **Save and Activate**:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Directus Operation Extension: Unique Slugify
 
-This Directus operation extension ensures that the `slug` (another field can be selected) field of a collection is unique by generating a slug based on the `title` (another field can be selected) field and add anm optional slug prefix. If the generated slug already exists, it appends a numeric suffix to make it unique.
+This Directus operation extension ensures that the `slug` (another field can be selected) field of a collection is unique by generating a slug based on the `title` (another field can be selected) field and add an optional slug prefix. If the generated slug already exists, it appends a numeric suffix to make it unique.
 
 ## Features
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-	"name": "directus-operation-unique-slugify",
+	"name": "directus-extension-unique-slugify",
 	"version": "1.0.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "directus-operation-unique-slugify",
+			"name": "directus-extension-unique-slugify",
 			"version": "1.0.5",
+			"license": "MIT",
 			"dependencies": {
 				"slugify": "^1.6.6"
 			},

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"homepage": "https://github.com/undercontr/directus-operation-unique-slugify",
 	"icon": "extension",
 	"license": "MIT",
-	"version": "1.0.5",
+	"version": "1.0.6",
 	"keywords": [
 		"directus",
 		"directus-extension",

--- a/src/api.ts
+++ b/src/api.ts
@@ -4,6 +4,7 @@ import slugify from "slugify";
 type Options = {
   valueField: string;
   slugField: string;
+  prefixField: string;
   separator: string;
 };
 
@@ -12,7 +13,7 @@ type Data = Record<string, any>;
 export default defineOperationApi<Options>({
   id: "operation-unique-slugify",
   handler: async (
-    { valueField, slugField, separator },
+    { valueField, slugField, prefixField, separator },
     { services, data: dataRaw, getSchema }
   ) => {
     const data = dataRaw as Data;
@@ -31,9 +32,12 @@ export default defineOperationApi<Options>({
       accountability: data.accountability,
     });
 
-    const baseSlug = slugify(title, {
+    const prefixedSlug = prefixField ? prefixField.replace(/^\/|\/$/g, '') + '/' + title : title;
+
+    const baseSlug = slugify(prefixedSlug, {
       lower: true,
       replacement: separator,
+      remove: /[*+~.()'"!:@]/g,
     });
 
     let uniqueSlug = baseSlug;

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,7 +5,7 @@ export default defineOperationApp({
 	name: 'Unique Slugify',
 	icon: 'box',
 	description: 'Slugify your fields ensuring uniqueness',
-	overview: ({ valueField, slugField, separator }) => [
+	overview: ({ valueField, slugField, prefixField, separator }) => [
 		{
 			label: 'Field to be used for slugging',
 			text: valueField,
@@ -13,6 +13,10 @@ export default defineOperationApp({
 		{
 			label: 'Field that slug should be assigned',
 			text: slugField,
+		},
+		{
+			label: 'Slug prefix',
+			text: prefixField,
 		},
 		{
 			label: "Define a character to be used space replacement",
@@ -36,6 +40,16 @@ export default defineOperationApp({
 			meta: {
 				width: 'half',
 				interface: 'input',
+			},
+		},
+		{
+			field: 'prefixField',
+			name: 'Slug prefix',
+			type: 'string',
+			meta: {
+				width: 'half',
+				interface: 'input',
+				note: 'Enter a prefix that is used in front of the title slug. Preceding and succeeding slashes are removed.',
 			},
 		},
 		{


### PR DESCRIPTION
I added a new field for adding an optional slug prefix. Preceding and succeeding forward slashes are removed when creating the slug in the collection. Also updated the readme to reflect the changes.